### PR TITLE
Fix: add **kwargs to _named_members for PyTorch 2.6+ compatibility

### DIFF
--- a/tensorlayerx/nn/core/core_torch.py
+++ b/tensorlayerx/nn/core/core_torch.py
@@ -125,7 +125,7 @@ class Module(T_Module):
     # TODO RNN enabled after repair
     __call__: Callable[..., Any] = _call_impl_tlx
 
-    def _named_members(self, get_members_fn, prefix='', recurse=True):
+    def _named_members(self, get_members_fn, prefix='', recurse=True, **kwargs):
         r"""Helper method for yielding various names + members of modules."""
         memo = set()
         modules = self.named_modules(prefix=prefix) if recurse else [(prefix, self)]


### PR DESCRIPTION
### Checklist / 检查清单
- [x] I've tested that my changes are compatible with the latest version of Tensorflow. (Changes are isolated to PyTorch backend `core_torch.py`, no impact on TF / 修改仅涉及 PyTorch 后端，不影响 TF)
- [x] I've read the [Contribution Guidelines](https://github.com/tensorlayer/tensorlayer/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary. (Internal bug fix, no documentation changes needed / 内部 Bug 修复，无需修改文档)

### Motivation and Context / 动机与背景
PyTorch 2.6+ introduces a new argument `remove_duplicate` in `named_parameters`, which causes a crash in the current TLX implementation.
PyTorch 2.6+ 在 `named_parameters` 中引入了新参数 `remove_duplicate`，导致当前 TLX 实现崩溃。

* **Why**: This fixes the `TypeError` crash on PyTorch 2.6/2.7+.
  **原因**: 修复了 PyTorch 2.6/2.7+ 环境下的 `TypeError` 报错。
* **Testing**: Verified locally with PyTorch 2.7 using GammaGL training script (Cora dataset).
  **测试**: 已在本地使用 PyTorch 2.7 和 GammaGL 训练脚本（Cora 数据集）验证通过。

### Description / 描述
This PR adds `**kwargs` to the `_named_members` method in `tensorlayerx/nn/core/core_torch.py`.
本 PR 在 `tensorlayerx/nn/core/core_torch.py` 的 `_named_members` 方法中添加了 `**kwargs`。

This allows the method to accept and ignore future arguments (like `remove_duplicate`) gracefully, ensuring forward compatibility with newer PyTorch versions.
这使得该方法能够优雅地接收并忽略未来的新参数（如 `remove_duplicate`），从而确保与新版 PyTorch 的向前兼容性。