### PR TITLE
Fix: backend config file not taking effect due to inverted logic and identity comparison

### DIFF
--- a/tensorlayerx/backend/ops/load_backend.py
+++ b/tensorlayerx/backend/ops/load_backend.py
@@ -32,10 +32,10 @@ else:
     path = os.path.join(tl_dir, 'tl_backend.json')
     with open(path, 'r') as load_f:
         load_dict = json.load(load_f)
-    if load_dict['backend'] is not config['backend']:
-        BACKEND = config['backend']
-    else:
+    if load_dict.get('backend') != config['backend']:
         BACKEND = load_dict['backend']
+    else:
+        BACKEND = config['backend']
 
 # Set backend based on TL_BACKEND.
 if 'TL_BACKEND' in os.environ:


### PR DESCRIPTION
 ## Bug Description                                                                                
                                                                                                    
  In `tensorlayerx/backend/ops/load_backend.py`, the config file `~/.tl/tl_backend.json`            
  does not take effect. Users who change the backend via config file still get the                  
  hardcoded default (`tensorflow`).                                                                 
                                                                                                    
  ## Root Cause                                                                                     
                                                                                                    
  Two issues in lines 34-37:                                                                        
                                                            
  ### 1. Inverted logic                                                                             
  ```python                                                 
  # Current code (WRONG):                                                                           
  if load_dict['backend'] is not config['backend']:                                                 
      BACKEND = config['backend']      # user changed backend, but we ignore it!                    
  else:                                                                                             
      BACKEND = load_dict['backend']   # values are equal, so this is same as default               
  ```
                                                                                                  
  When the user configures a different backend from the default, the code                           
  overwrites it with the hardcoded default instead of respecting the user's choice.                 
                                                                                                    
  ### 2. is not for string comparison                                                                   
                                                                                                    
  is not compares object identity (memory address), not value equality.                             
  It should use !=.                                         
                                                                                                    
  ### Fix                                                                                               
  ```python                                                                                                    
  if load_dict.get('backend') != config['backend']:                                                 
      BACKEND = load_dict['backend']                                                                
  else:                                                                                             
      BACKEND = config['backend']                                                                   
  ```
                                                                                                    
 ### Reproduce                                                                                         
                                                                                                    
  1. Install tensorlayerx in an environment with PyTorch but without TensorFlow                     
  2. Edit ~/.tl/tl_backend.json: {"backend": "torch"}       
  3. import tensorlayerx → ModuleNotFoundError: No module named 'tensorflow'                        
                                                                                                    
  Expected: should load PyTorch backend.                                                            
                                                                                                    
### Note                                                                                              
                                                            
  The TL_BACKEND environment variable workaround still works (lines 39-43),                         
  so users relying on that are not affected.  